### PR TITLE
Replaced OS X security with cert-downloader module

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,14 +1,13 @@
 'use strict';
 
-var exec = require('child_process').exec;
 var plist = require('simple-plist');
 
 module.exports = function(file, callback){
-  exec('security cms -D -i ' + file, function(error, output){
+  var certDl = new (require('cert-downloader'));
+  certDl.verify(file, function(error, output) {
     if(error){
       return callback(error);
     }
-
     callback(null, plist.parse(output));
   });
 };

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   },
   "homepage": "https://github.com/matiassingers/provisioning",
   "dependencies": {
+    "cert-downloader": "0.0.4",
     "simple-plist": "0.0.4"
   },
   "devDependencies": {

--- a/readme.md
+++ b/readme.md
@@ -3,8 +3,6 @@
 
 Converts the provisioning profile raw plist data into JavaScript objects, arrays, etc.
 
-**Note:** this module currently only works on OS X because of [`security`], see [#3](https://github.com/matiassingers/ipa-metadata/pull/3).
-
 ## Install
 
 ```sh
@@ -56,5 +54,3 @@ $ provisioning --help
 ## License
 
 MIT © [Matias Singers](http://mts.io)
-
-[`security`]: https://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man1/security.1.html

--- a/test.js
+++ b/test.js
@@ -5,13 +5,17 @@ var fs = require('fs');
 var plistFixture = fs.readFileSync('./fixtures/fixture.plist', { encoding: 'UTF-8' });
 
 var proxyquire =  require('proxyquire');
-var childProcessStub = {
-  exec: function(command, callback){
-    callback(null, plistFixture);
-  }
-};
 
-var provisioning = proxyquire('./', {'child_process': childProcessStub});
+var CertDownloaderStub = (function (options) {
+  function CertDownloader(options) {
+  }
+  CertDownloader.prototype.verify = function(file, callback) {
+    callback(null, plistFixture);
+  };
+  return CertDownloader;
+})();
+
+var provisioning = proxyquire('./', {'cert-downloader': CertDownloaderStub});
 
 describe('should call exec correctly and parse plist data', function(){
   it('return parsed data as object', function(done) {


### PR DESCRIPTION
Hi,

In reference to [ipa-metadata](https://github.com/matiassingers/ipa-metadata) [#8](https://github.com/matiassingers/ipa-metadata/issues/8) and [#3](https://github.com/matiassingers/ipa-metadata/pull/3) I'd like to suggest this change to make provisioning work on other systems than OS X.

As you [suggested](https://github.com/matiassingers/ipa-metadata/pull/3#issuecomment-70958045), I have taken the security/ssl/certificate code and packaged it as a separate module and made a small change to provisioning that calls said module.

I've tested this on OS X 10.10.3 and Debian 7.8 so far and will keep trying to break it.

This could be the first step in the process of making ipa-metadata more OS agnostic, since it doesn't touch the `codesign` in [entitlements](https://github.com/matiassingers/entitlements).
