### PR TITLE
Update cert-download

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
 var plist = require('simple-plist');
 
 module.exports = function(file, callback){
-  var certDl = new (require('cert-downloader'));
+  var certDl = new (require('@stendahls/cert-downloader'));
   certDl.verify(file, function(error, output) {
     if(error){
       return callback(error);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,257 @@
+{
+  "name": "provisioning",
+  "version": "1.5.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@stendahls/cert-downloader": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@stendahls/cert-downloader/-/cert-downloader-1.0.0.tgz",
+      "integrity": "sha512-QL4E19sG/RQWvwyNl3KiNR/RSlHC+yI7RmO70UcVCrppFXlbrSuXLhJjZJxtuZpxjFTdzHwVy/0ZIL/E2UfUdg=="
+    },
+    "base64-js": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.6.tgz",
+      "integrity": "sha1-e4WfefC7vVWGe6Z6f6s5fiSiCUc="
+    },
+    "bplist-creator": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/bplist-creator/-/bplist-creator-0.0.4.tgz",
+      "integrity": "sha1-SsBJZ4LhJ6hcHSAmpPXrIqev+ZE=",
+      "requires": {
+        "stream-buffers": "~0.2.3"
+      }
+    },
+    "bplist-parser": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.0.6.tgz",
+      "integrity": "sha1-ONo0cYF9+dRKs4kuJ3B7u9daEbk="
+    },
+    "commander": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
+      "integrity": "sha1-/UMOiJgy7DU7ms0d4hfBHLPu+HM=",
+      "dev": true
+    },
+    "debug": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.0.0.tgz",
+      "integrity": "sha1-ib2d9nMrUSVrxnBTQrugLtEhMe8=",
+      "dev": true,
+      "requires": {
+        "ms": "0.6.2"
+      }
+    },
+    "diff": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
+      "integrity": "sha1-fyjS657nsVqX79ic5j3P2qPMur8=",
+      "dev": true
+    },
+    "escape-string-regexp": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
+      "integrity": "sha1-Tbwv5nTnGUnK8/smlc5/LcHZqNE=",
+      "dev": true
+    },
+    "fill-keys": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/fill-keys/-/fill-keys-1.0.2.tgz",
+      "integrity": "sha1-mo+jb06K1jTjv2tPPIiCVRRS6yA=",
+      "dev": true,
+      "requires": {
+        "is-object": "~1.0.1",
+        "merge-descriptors": "~1.0.0"
+      }
+    },
+    "glob": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.3.tgz",
+      "integrity": "sha1-4xPusknHr/qlxHUoaw4RW1mDlGc=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "~2.0.0",
+        "inherits": "2",
+        "minimatch": "~0.2.11"
+      }
+    },
+    "graceful-fs": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz",
+      "integrity": "sha1-fNLNsiiko/Nule+mzBQt59GhNtA=",
+      "dev": true
+    },
+    "growl": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.8.1.tgz",
+      "integrity": "sha1-Sy3sjZB+k9szZiTc7AGDUC+MlCg=",
+      "dev": true
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "is-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
+      "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA=",
+      "dev": true
+    },
+    "jade": {
+      "version": "0.26.3",
+      "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
+      "integrity": "sha1-jxDXl32NefL2/4YqgbBRPMslaGw=",
+      "dev": true,
+      "requires": {
+        "commander": "0.6.1",
+        "mkdirp": "0.3.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
+          "integrity": "sha1-+mihT2qUXVTbvlDYzbMyDp47GgY=",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
+          "integrity": "sha1-G79asbqCevI1dRQ0kEJkVfSB/h4=",
+          "dev": true
+        }
+      }
+    },
+    "lodash-node": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash-node/-/lodash-node-2.4.1.tgz",
+      "integrity": "sha1-6oL3sQDHM9GkKvdoAeUGEF4qgOw="
+    },
+    "lru-cache": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+      "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
+      "dev": true
+    },
+    "merge-descriptors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+      "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
+      "dev": true,
+      "requires": {
+        "lru-cache": "2",
+        "sigmund": "~1.0.0"
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
+    },
+    "mkdirp": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+      "integrity": "sha1-HXMHam35hs2TROFecfzAWkyavxI=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      }
+    },
+    "mocha": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-2.2.5.tgz",
+      "integrity": "sha1-07cqT+SeyUOTU/GsiT28Qw2ZMUA=",
+      "dev": true,
+      "requires": {
+        "commander": "2.3.0",
+        "debug": "2.0.0",
+        "diff": "1.4.0",
+        "escape-string-regexp": "1.0.2",
+        "glob": "3.2.3",
+        "growl": "1.8.1",
+        "jade": "0.26.3",
+        "mkdirp": "0.5.0",
+        "supports-color": "~1.2.0"
+      }
+    },
+    "ms": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz",
+      "integrity": "sha1-2JwhJMb9wTU9Zai3e/GqxLGTcIw=",
+      "dev": true
+    },
+    "plist": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/plist/-/plist-1.1.0.tgz",
+      "integrity": "sha1-/2cIWQyXzEOOe8Rd5SUb1yXz+J0=",
+      "requires": {
+        "base64-js": "0.0.6",
+        "util-deprecate": "1.0.0",
+        "xmlbuilder": "2.2.1",
+        "xmldom": "0.1.x"
+      }
+    },
+    "proxyquire": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/proxyquire/-/proxyquire-1.5.0.tgz",
+      "integrity": "sha1-Hqh/g+RvRd0cP3xNA6vyJenfPwI=",
+      "dev": true,
+      "requires": {
+        "fill-keys": "^1.0.0"
+      }
+    },
+    "sigmund": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
+      "dev": true
+    },
+    "simple-plist": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/simple-plist/-/simple-plist-0.0.4.tgz",
+      "integrity": "sha1-f4Y0OLY8t135ndgbgzbXxQdc/As=",
+      "requires": {
+        "bplist-creator": "0.0.4",
+        "bplist-parser": "0.0.6",
+        "plist": "1.1.0"
+      }
+    },
+    "stream-buffers": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-0.2.6.tgz",
+      "integrity": "sha1-GBwI1bs2kARfaUAbmuanoM8zE/w="
+    },
+    "supports-color": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.2.1.tgz",
+      "integrity": "sha1-Eu4hUHCGzZjBBY2ewPSsR2t687I=",
+      "dev": true
+    },
+    "util-deprecate": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.0.tgz",
+      "integrity": "sha1-MAevASwUDq4m3gVXbsInhcrDq/I="
+    },
+    "xmlbuilder": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-2.2.1.tgz",
+      "integrity": "sha1-kyZDDxMNh0NdTECGZDqikm4QWjI=",
+      "requires": {
+        "lodash-node": "~2.4.1"
+      }
+    },
+    "xmldom": {
+      "version": "0.1.27",
+      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.27.tgz",
+      "integrity": "sha1-1QH5ezvbQDr4757MIFcxh6rawOk="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "homepage": "https://github.com/matiassingers/provisioning",
   "dependencies": {
-    "cert-downloader": "0.2.1",
+    "cert-downloader": "github:stendahls/cert-downloader",
     "simple-plist": "0.0.4"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "homepage": "https://github.com/matiassingers/provisioning",
   "dependencies": {
-    "cert-downloader": "github:stendahls/cert-downloader",
+    "@stendahls/cert-downloader": "^1.0.0",
     "simple-plist": "0.0.4"
   },
   "devDependencies": {


### PR DESCRIPTION
Basically the old cert-download uses a deprecated function in fs.exists which fails on newer node versions. 

This dep updates that so it's compatible with current node versions